### PR TITLE
Set `additionalProperties` to `nil` by default

### DIFF
--- a/lib/open_api_spex/schema.ex
+++ b/lib/open_api_spex/schema.ex
@@ -37,7 +37,7 @@ defmodule OpenApiSpex.Schema do
     :not,
     :items,
     :properties,
-    {:additionalProperties, true},
+    {:additionalProperties, nil},
     :description,
     :format,
     :default,


### PR DESCRIPTION
Hi,

Not sure whether this is necessary as I'm not very familiar with Swagger. But I found by default, all the models contain `additionalProperties: true` in the Swagger UI:

![](https://user-images.githubusercontent.com/31945/33462415-8a4f0ff8-d68b-11e7-96bd-d46f47dd5777.png)

I have to then pass in `additionalProperties: nil` to every single `%Schema{}` to get rid of them.

![](https://user-images.githubusercontent.com/31945/33462424-9d46a1de-d68b-11e7-8d0b-5eb1ffc61149.png)

This PR sets `additionalProperties` to `nil` by default.