### PR TITLE
Empty map as default value for properties. Handle additionalProperties correctly.

### DIFF
--- a/lib/open_api_spex/schema.ex
+++ b/lib/open_api_spex/schema.ex
@@ -36,7 +36,7 @@ defmodule OpenApiSpex.Schema do
     :anyOf,
     :not,
     :items,
-    :properties,
+    {:properties, %{}},
     {:additionalProperties, nil},
     :description,
     :format,
@@ -190,7 +190,9 @@ defmodule OpenApiSpex.Schema do
     end
   end
   def cast(ref = %Reference{}, val, schemas), do: cast(Reference.resolve_schema(ref, schemas), val, schemas)
-  def cast(additionalProperties, val, _schemas) when additionalProperties in [true, false, nil], do: {:ok, val}
+  def cast(additionalProperties, val, _schemas) when additionalProperties in [nil, false], do:
+    {:error, "Unexpected field with value #{inspect(val)}"}
+  def cast(additionalProperties, val, _schemas) when additionalProperties, do: {:ok, val}
 
   @spec cast_properties(Schema.t, list, %{String.t => Schema.t}) :: {:ok, list} | {:error, String.t}
   defp cast_properties(%Schema{}, [], _schemas), do: {:ok, []}

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -32,6 +32,29 @@ defmodule OpenApiSpex.SchemaTest do
     }
   end
 
+  test "cast request schema with unexpected fields returns error" do
+    api_spec = ApiSpec.spec()
+    schemas = api_spec.components.schemas
+    user_request_schema = schemas["UserRequest"]
+
+    input = %{
+      "user" => %{
+        "id" => 123,
+        "name" => "asdf",
+        "email" => "foo@bar.com",
+        "updated_at" => "2017-09-12T14:44:55Z",
+        "unexpected_field" => "unexpected value"
+      }
+    }
+
+    assert {:error, _} = Schema.cast(user_request_schema, input, schemas)
+  end
+
+  test "EntityWithDict Schema example matches schema" do
+    api_spec = ApiSpec.spec()
+    assert_schema(Schemas.EntityWithDict.schema().example, "EntityWithDict", api_spec)
+  end
+
   test "User Schema example matches schema" do
     spec = ApiSpec.spec()
     assert_schema(Schemas.User.schema().example, "User", spec)

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -14,6 +14,7 @@ defmodule OpenApiSpexTest.Router do
     pipe_through :api
     resources "/users", UserController, only: [:create, :index, :show]
     get "/users/:id/payment_details", UserController, :payment_details
+    post "/users/create_entity", UserController, :create_entity
     get "/openapi", RenderSpec, []
   end
 end

--- a/test/support/schemas.ex
+++ b/test/support/schemas.ex
@@ -137,4 +137,22 @@ defmodule OpenApiSpexTest.Schemas do
       }
     }
   end
+
+  defmodule EntityWithDict do
+    OpenApiSpex.schema %{
+      title: "EntityWithDict",
+      description: "Entity with a dictionary defined via additionalProperties",
+      type: :object,
+      properties: %{
+        id: %Schema{type: :integer, description: "Entity ID"},
+        stringDict: %Schema{type: :object, description: "String valued dict", additionalProperties: %Schema{type: :string}},
+        anyTypeDict: %Schema{type: :object, description: "Untyped valued dict", additionalProperties: true},
+      },
+      example: %{
+        "id" => 123,
+        "stringDict" => %{"key1" => "value1", "key2" => "value2"},
+        "anyTypeDict" => %{"key1" => 42, "key2" => %{"foo" => "bar"}}
+      }
+    }
+  end
 end

--- a/test/support/user_controller.ex
+++ b/test/support/user_controller.ex
@@ -119,4 +119,22 @@ defmodule OpenApiSpexTest.UserController do
 
       json(conn, response)
   end
+
+  def create_entity_operation() do
+    import Operation
+    %Operation{
+      tags: ["EntityWithDict"],
+      summary: "Create an EntityWithDict",
+      description: "Create an EntityWithDict",
+      operationId: "UserController.create_entity",
+      parameters: [],
+      requestBody: request_body("Entity attributes", "application/json", Schemas.EntityWithDict),
+      responses: %{
+        201 => response("EntityWithDict", "application/json", Schemas.EntityWithDict)
+      }
+    }
+  end
+  def create_entity(conn, %Schemas.EntityWithDict{} = entity) do
+    json(conn, Map.put(entity, :id, 123))
+  end
 end


### PR DESCRIPTION
Make an empty map as a default value for Schema.properties. 
Handle additionalProperties correctly.
Return an error if unexpected field is passed as a value to be casted.