### PR TITLE
operation typespec fixed (requestBody)

### DIFF
--- a/lib/open_api_spex/operation.ex
+++ b/lib/open_api_spex/operation.ex
@@ -44,7 +44,7 @@ defmodule OpenApiSpex.Operation do
     externalDocs: ExternalDocumentation.t | nil,
     operationId: String.t | nil,
     parameters: [Parameter.t | Reference.t] | nil,
-    requestBody: [RequestBody.t | Reference.t] | nil,
+    requestBody: RequestBody.t | Reference.t | nil,
     responses: Responses.t,
     callbacks: %{String.t => Callback.t | Reference.t} | nil,
     deprecated: boolean | nil,


### PR DESCRIPTION
* requestBody is now defined as single object instead of a list of objects
* as defined in https://swagger.io/specification/#operationObject

Hello @mbuhot ,

i found a bug in the operation type spec and fixed it.

Greetings, Thomas