### PR TITLE
allowing non required fields in Components to be nil

### DIFF
--- a/lib/open_api_spex/components.ex
+++ b/lib/open_api_spex/components.ex
@@ -27,14 +27,14 @@ defmodule OpenApiSpex.Components do
   they are explicitly referenced from properties outside the components object.
   """
   @type t :: %Components{
-    schemas: %{String.t => Schema.t | Reference.t},
-    responses: %{String.t =>  Response.t | Reference.t},
-    parameters: %{String.t =>  Parameter.t | Reference.t},
-    examples: %{String.t => Example.t | Reference.t},
-    requestBodies: %{String.t => RequestBody.t | Reference.t},
-    headers: %{String.t =>  Header.t | Reference.t},
-    securitySchemes: %{String.t =>  SecurityScheme.t | Reference.t},
-    links: %{String.t => Link.t | Reference.t},
-    callbacks: %{String.t => Callback.t | Reference.t}
+    schemas: %{String.t => Schema.t | Reference.t} | nil,
+    responses: %{String.t =>  Response.t | Reference.t} | nil,
+    parameters: %{String.t =>  Parameter.t | Reference.t} | nil,
+    examples: %{String.t => Example.t | Reference.t} | nil,
+    requestBodies: %{String.t => RequestBody.t | Reference.t} | nil,
+    headers: %{String.t =>  Header.t | Reference.t} | nil,
+    securitySchemes: %{String.t =>  SecurityScheme.t | Reference.t} | nil,
+    links: %{String.t => Link.t | Reference.t} | nil,
+    callbacks: %{String.t => Callback.t | Reference.t} | nil
   }
 end

--- a/lib/open_api_spex/open_api.ex
+++ b/lib/open_api_spex/open_api.ex
@@ -27,11 +27,11 @@ defmodule OpenApiSpex.OpenApi do
   @type t :: %OpenApi{
     openapi: String.t,
     info: Info.t,
-    servers: [Server.t],
+    servers: [Server.t] | nil,
     paths: Paths.t,
     components: Components.t | nil,
-    security: [SecurityRequirement.t],
-    tags: [Tag.t],
+    security: [SecurityRequirement.t] | nil,
+    tags: [Tag.t] | nil,
     externalDocs: ExternalDocumentation.t | nil
   }
 

--- a/lib/open_api_spex/security_scheme.ex
+++ b/lib/open_api_spex/security_scheme.ex
@@ -23,12 +23,12 @@ defmodule OpenApiSpex.SecurityScheme do
   """
   @type t :: %__MODULE__{
     type: String.t,
-    description: String.t,
-    name: String.t,
-    in: String.t,
-    scheme: String.t,
-    bearerFormat: String.t,
-    flows: OAuthFlows.t,
-    openIdConnectUrl: String.t
+    description: String.t | nil,
+    name: String.t | nil,
+    in: String.t | nil,
+    scheme: String.t | nil,
+    bearerFormat: String.t | nil,
+    flows: OAuthFlows.t | nil,
+    openIdConnectUrl: String.t | nil
   }
 end


### PR DESCRIPTION
* in open_api, components and security_scheme structs to be nil
* as defined in https://swagger.io/specification

Hey @mbuhot ,

i updated the spec as we discussed in #18. I only updated the security scheme struct and the parents structs it belongs to. 
I guess there might be some more non-required fields in other specs that arent 100% in sync. But for now i only updated the ones i needed right now.

Greetings, Thomas