### PR TITLE
Update types and @enforce_keys for optional/required fields

### DIFF
--- a/lib/open_api_spex/contact.ex
+++ b/lib/open_api_spex/contact.ex
@@ -15,8 +15,8 @@ defmodule OpenApiSpex.Contact do
   Contact information for the exposed API.
   """
   @type t :: %__MODULE__{
-    name: String.t,
-    url: String.t,
-    email: String.t
+    name: String.t | nil,
+    url: String.t | nil,
+    email: String.t | nil
   }
 end

--- a/lib/open_api_spex/discriminator.ex
+++ b/lib/open_api_spex/discriminator.ex
@@ -2,6 +2,8 @@ defmodule OpenApiSpex.Discriminator do
   @moduledoc """
   Defines the `OpenApiSpex.Discriminator.t` type.
   """
+
+  @enforce_keys :propertyName
   defstruct [
     :propertyName,
     :mapping
@@ -17,6 +19,6 @@ defmodule OpenApiSpex.Discriminator do
   """
   @type t :: %__MODULE__{
     propertyName: String.t,
-    mapping: %{String.t => String.t}
+    mapping: %{String.t => String.t} | nil
   }
 end

--- a/lib/open_api_spex/encoding.ex
+++ b/lib/open_api_spex/encoding.ex
@@ -17,10 +17,10 @@ defmodule OpenApiSpex.Encoding do
   A single encoding definition applied to a single schema property.
   """
   @type t :: %__MODULE__{
-    contentType: String.t,
-    headers: %{String.t => Header.t | Reference.t},
-    style: Parameter.style,
-    explode: boolean,
-    allowReserved: boolean
+    contentType: String.t | nil,
+    headers: %{String.t => Header.t | Reference.t} | nil,
+    style: Parameter.style | nil,
+    explode: boolean | nil,
+    allowReserved: boolean | nil
   }
 end

--- a/lib/open_api_spex/example.ex
+++ b/lib/open_api_spex/example.ex
@@ -15,9 +15,9 @@ defmodule OpenApiSpex.Example do
   In all cases, the example value is expected to be compatible with the type schema of its associated value.
   """
   @type t :: %__MODULE__{
-    summary: String.t,
-    description: String.t,
+    summary: String.t | nil,
+    description: String.t | nil,
     value: any,
-    externalValue: String.t
+    externalValue: String.t | nil
   }
 end

--- a/lib/open_api_spex/external_documentation.ex
+++ b/lib/open_api_spex/external_documentation.ex
@@ -2,6 +2,8 @@ defmodule OpenApiSpex.ExternalDocumentation do
   @moduledoc """
   Defines the `OpenApiSpex.ExternalDocumentation.t` type.
   """
+
+  @enforce_keys :url
   defstruct [
     :description,
     :url
@@ -13,7 +15,7 @@ defmodule OpenApiSpex.ExternalDocumentation do
   Allows referencing an external resource for extended documentation.
   """
   @type t :: %__MODULE__{
-    description: String.t,
+    description: String.t | nil,
     url: String.t
   }
 end

--- a/lib/open_api_spex/header.ex
+++ b/lib/open_api_spex/header.ex
@@ -25,14 +25,14 @@ defmodule OpenApiSpex.Header do
    - All traits that are affected by the location MUST be applicable to a location of header (for example, style).
   """
   @type t :: %__MODULE__{
-    description: String.t,
-    required: boolean,
-    deprecated: boolean,
-    allowEmptyValue: boolean,
+    description: String.t | nil,
+    required: boolean | nil,
+    deprecated: boolean | nil,
+    allowEmptyValue: boolean | nil,
     style: :simple,
-    explode: boolean,
-    schema: Schema.t | Reference.t,
+    explode: boolean | nil,
+    schema: Schema.t | Reference.t | nil,
     example: any,
-    examples: %{String.t => Example.t | Reference.t}
+    examples: %{String.t => Example.t | Reference.t} | nil
   }
 end

--- a/lib/open_api_spex/license.ex
+++ b/lib/open_api_spex/license.ex
@@ -2,6 +2,8 @@ defmodule OpenApiSpex.License do
   @moduledoc """
   Defines the `OpenApiSpex.License.t` type.
   """
+
+  @enforce_keys :name
   defstruct [
     :name,
     :url
@@ -14,6 +16,6 @@ defmodule OpenApiSpex.License do
   """
   @type t :: %__MODULE__{
     name: String.t,
-    url: String.t
+    url: String.t | nil
   }
 end

--- a/lib/open_api_spex/link.ex
+++ b/lib/open_api_spex/link.ex
@@ -28,11 +28,11 @@ defmodule OpenApiSpex.Link do
   using them as parameters while invoking the linked operation.
   """
   @type t :: %__MODULE__{
-    operationRef: String.t,
-    operationId: String.t,
-    parameters: %{String.t => any},
+    operationRef: String.t | nil,
+    operationId: String.t | nil,
+    parameters: %{String.t => any} | nil,
     requestBody: any,
-    description: String.t,
-    server: Server.t
+    description: String.t | nil,
+    server: Server.t | nil
   }
 end

--- a/lib/open_api_spex/media_type.ex
+++ b/lib/open_api_spex/media_type.ex
@@ -16,9 +16,9 @@ defmodule OpenApiSpex.MediaType do
   Each Media Type Object provides schema and examples for the media type identified by its key.
   """
   @type t :: %__MODULE__{
-    schema: Schema.t | Reference.t,
+    schema: Schema.t | Reference.t | nil,
     example: any,
-    examples: %{String.t => Example.t | Reference.t},
-    encoding: %{String => Encoding.t}
+    examples: %{String.t => Example.t | Reference.t} | nil,
+    encoding: %{String => Encoding.t} | nil
   }
 end

--- a/lib/open_api_spex/oauth_flow.ex
+++ b/lib/open_api_spex/oauth_flow.ex
@@ -15,9 +15,9 @@ defmodule OpenApiSpex.OAuthFlow do
   Configuration details for a supported OAuth Flow
   """
   @type t :: %__MODULE__{
-    authorizationUrl: String.t,
-    tokenUrl: String.t,
-    refreshUrl: String.t,
-    scopes: %{String.t => String.t}
+    authorizationUrl: String.t | nil,
+    tokenUrl: String.t | nil,
+    refreshUrl: String.t | nil,
+    scopes: %{String.t => String.t} | nil
   }
 end

--- a/lib/open_api_spex/oauth_flows.ex
+++ b/lib/open_api_spex/oauth_flows.ex
@@ -16,9 +16,9 @@ defmodule OpenApiSpex.OAuthFlows do
   Allows configuration of the supported OAuth Flows.
   """
   @type t :: %__MODULE__{
-    implicit: OAuthFlow.t,
-    password: OAuthFlow.t,
-    clientCredentials: OAuthFlow.t,
-    authorizationCode: OAuthFlow.t
+    implicit: OAuthFlow.t | nil,
+    password: OAuthFlow.t | nil,
+    clientCredentials: OAuthFlow.t | nil,
+    authorizationCode: OAuthFlow.t | nil
   }
 end

--- a/lib/open_api_spex/operation.ex
+++ b/lib/open_api_spex/operation.ex
@@ -17,6 +17,7 @@ defmodule OpenApiSpex.Operation do
     Server,
   }
 
+  @enforce_keys :responses
   defstruct [
     :tags,
     :summary,

--- a/lib/open_api_spex/parameter.ex
+++ b/lib/open_api_spex/parameter.ex
@@ -5,6 +5,8 @@ defmodule OpenApiSpex.Parameter do
   alias OpenApiSpex.{
     Schema, Reference, Example, MediaType, Parameter
   }
+
+  @enforce_keys [:name, :in]
   defstruct [
     :name,
     :in,
@@ -49,17 +51,17 @@ defmodule OpenApiSpex.Parameter do
   @type t :: %__MODULE__{
     name: atom,
     in: location,
-    description: String.t,
-    required: boolean,
-    deprecated: boolean,
-    allowEmptyValue: boolean,
-    style: style,
-    explode: boolean,
-    allowReserved: boolean,
-    schema: Schema.t | Reference.t | atom,
+    description: String.t | nil,
+    required: boolean | nil,
+    deprecated: boolean | nil,
+    allowEmptyValue: boolean | nil,
+    style: style | nil,
+    explode: boolean | nil,
+    allowReserved: boolean | nil,
+    schema: Schema.t | Reference.t | atom | nil,
     example: any,
-    examples: %{String.t => Example.t | Reference.t},
-    content: %{String.t => MediaType.t}
+    examples: %{String.t => Example.t | Reference.t} | nil,
+    content: %{String.t => MediaType.t} | nil
   }
 
   @doc """

--- a/lib/open_api_spex/path_item.ex
+++ b/lib/open_api_spex/path_item.ex
@@ -29,19 +29,19 @@ defmodule OpenApiSpex.PathItem do
   but they will not know which operations and parameters are available.
   """
   @type t :: %__MODULE__{
-    "$ref": String.t,
-    summary: String.t,
-    description: String.t,
-    get: Operation.t,
-    put: Operation.t,
-    post: Operation.t,
-    delete: Operation.t,
-    options: Operation.t,
-    head: Operation.t,
-    patch: Operation.t,
-    trace: Operation.t,
-    servers: [Server.t],
-    parameters: [Parameter.t | Reference.t]
+    "$ref": String.t | nil,
+    summary: String.t | nil,
+    description: String.t | nil,
+    get: Operation.t | nil,
+    put: Operation.t | nil,
+    post: Operation.t | nil,
+    delete: Operation.t | nil,
+    options: Operation.t | nil,
+    head: Operation.t | nil,
+    patch: Operation.t | nil,
+    trace: Operation.t | nil,
+    servers: [Server.t] | nil,
+    parameters: [Parameter.t | Reference.t] | nil
   }
 
   @typedoc """

--- a/lib/open_api_spex/reference.ex
+++ b/lib/open_api_spex/reference.ex
@@ -5,6 +5,7 @@ defmodule OpenApiSpex.Reference do
 
   alias OpenApiSpex.Reference
 
+  @enforce_keys :"$ref"
   defstruct [
     :"$ref"
   ]

--- a/lib/open_api_spex/request_body.ex
+++ b/lib/open_api_spex/request_body.ex
@@ -3,6 +3,8 @@ defmodule OpenApiSpex.RequestBody do
   Defines the `OpenApiSpex.RequestBody.t` type.
   """
   alias OpenApiSpex.MediaType
+
+  @enforce_keys :content
   defstruct [
     :description,
     :content,
@@ -15,7 +17,7 @@ defmodule OpenApiSpex.RequestBody do
   Describes a single request body.
   """
   @type t :: %__MODULE__{
-    description: String.t,
+    description: String.t | nil,
     content: %{String.t => MediaType.t},
     required: boolean
   }

--- a/lib/open_api_spex/response.ex
+++ b/lib/open_api_spex/response.ex
@@ -3,6 +3,8 @@ defmodule OpenApiSpex.Response do
   Defines the `OpenApiSpex.Response.t` type.
   """
   alias OpenApiSpex.{Header, Reference, MediaType, Link}
+
+  @enforce_keys :description
   defstruct [
     :description,
     :headers,
@@ -18,7 +20,7 @@ defmodule OpenApiSpex.Response do
   @type t :: %__MODULE__{
     description: String.t,
     headers: %{String.t => Header.t | Reference.t} | nil,
-    content: %{String.t => MediaType.t},
+    content: %{String.t => MediaType.t} | nil,
     links: %{String.t => Link.t | Reference.t} | nil
   }
 end

--- a/lib/open_api_spex/responses.ex
+++ b/lib/open_api_spex/responses.ex
@@ -14,7 +14,6 @@ defmodule OpenApiSpex.Responses do
   The Responses Object MUST contain at least one response code, and it SHOULD be the response for a successful operation call.
   """
   @type t :: %{
-    :default => Response.t | Reference.t,
-    integer => Response.t | Reference.t
+    (integer | :default) => Response.t | Reference.t
   }
 end

--- a/lib/open_api_spex/schema.ex
+++ b/lib/open_api_spex/schema.ex
@@ -13,6 +13,7 @@ defmodule OpenApiSpex.Schema do
   """
   @callback schema() :: t
 
+  @enforce_keys :type
   defstruct [
     :title,
     :multipleOf,
@@ -37,7 +38,7 @@ defmodule OpenApiSpex.Schema do
     :not,
     :items,
     :properties,
-    {:additionalProperties, nil},
+    :additionalProperties,
     :description,
     :format,
     :default,
@@ -79,7 +80,7 @@ defmodule OpenApiSpex.Schema do
       }
   """
   @type t :: %__MODULE__{
-    title: String.t,
+    title: String.t | nil,
     multipleOf: number | nil,
     maximum: number | nil,
     exclusiveMaximum: boolean | nil,
@@ -103,9 +104,9 @@ defmodule OpenApiSpex.Schema do
     items: Schema.t | Reference.t | module | nil,
     properties: %{atom => Schema.t | Reference.t | module} | nil,
     additionalProperties: boolean | Schema.t | Reference.t | module | nil,
-    description: String.t,
+    description: String.t | nil,
     format: String.t | nil,
-    default: any | nil,
+    default: any,
     nullable: boolean | nil,
     discriminator: Discriminator.t | nil,
     readOnly: boolean | nil,

--- a/lib/open_api_spex/security_scheme.ex
+++ b/lib/open_api_spex/security_scheme.ex
@@ -3,6 +3,8 @@ defmodule OpenApiSpex.SecurityScheme do
   Defines the `OpenApiSpex.SecurityScheme.t` type.
   """
   alias OpenApiSpex.OAuthFlows
+
+  @enforce_keys :type
   defstruct [
     :type,
     :description,

--- a/lib/open_api_spex/server.ex
+++ b/lib/open_api_spex/server.ex
@@ -3,6 +3,8 @@ defmodule OpenApiSpex.Server do
   Defines the `OpenApiSpex.Server.t` type.
   """
   alias OpenApiSpex.{Server, ServerVariable}
+
+  @enforce_keys :url
   defstruct [
     :url,
     :description,

--- a/lib/open_api_spex/server_variable.ex
+++ b/lib/open_api_spex/server_variable.ex
@@ -2,6 +2,8 @@ defmodule OpenApiSpex.ServerVariable do
   @moduledoc """
   Defines the `OpenApiSpex.ServerVariable.t` type.
   """
+
+  @enforce_keys :default
   defstruct [
     :enum,
     :default,
@@ -14,8 +16,8 @@ defmodule OpenApiSpex.ServerVariable do
   An object representing a Server Variable for server URL template substitution.
   """
   @type t :: %__MODULE__{
-    enum: [String.t],
+    enum: [String.t] | nil,
     default: String.t,
-    description: String.t
+    description: String.t | nil
   }
 end

--- a/lib/open_api_spex/tag.ex
+++ b/lib/open_api_spex/tag.ex
@@ -4,6 +4,8 @@ defmodule OpenApiSpex.Tag do
   """
 
   alias OpenApiSpex.ExternalDocumentation
+
+  @enforce_keys :name
   defstruct [
     :name,
     :description,
@@ -18,7 +20,7 @@ defmodule OpenApiSpex.Tag do
   """
   @type t :: %__MODULE__{
     name: String.t,
-    description: String.t,
-    externalDocs: ExternalDocumentation.t
+    description: String.t | nil,
+    externalDocs: ExternalDocumentation.t | nil
   }
 end

--- a/lib/open_api_spex/xml.ex
+++ b/lib/open_api_spex/xml.ex
@@ -18,10 +18,10 @@ defmodule OpenApiSpex.Xml do
   and the name property SHOULD be used to add that information. See examples for expected behavior.
   """
   @type t :: %__MODULE__{
-    name: String.t,
-    namespace: String.t,
-    prefix: String.t,
-    attribute: boolean,
-    wrapped: boolean
+    name: String.t | nil,
+    namespace: String.t | nil,
+    prefix: String.t | nil,
+    attribute: boolean | nil,
+    wrapped: boolean | nil
   }
 end

--- a/test/schema_resolver_test.exs
+++ b/test/schema_resolver_test.exs
@@ -24,6 +24,7 @@ defmodule OpenApiSpex.SchemaResolverTest do
           get: %Operation{
             responses: %{
               200 => %Response{
+                description: "Success",
                 content: %{
                   "application/json" => %MediaType{
                     schema: OpenApiSpexTest.Schemas.UsersResponse
@@ -44,6 +45,7 @@ defmodule OpenApiSpex.SchemaResolverTest do
             },
             responses: %{
               201 => %Response{
+                description: "Created",
                 content: %{
                   "application/json" => %MediaType{
                     schema: OpenApiSpexTest.Schemas.UserResponse
@@ -57,6 +59,7 @@ defmodule OpenApiSpex.SchemaResolverTest do
           get: %Operation{
             responses: %{
               200 => %Response{
+                description: "Success",
                 content: %{
                   "application/json" => %MediaType{
                     schema: OpenApiSpexTest.Schemas.PaymentDetails


### PR DESCRIPTION
Update struct and type definitions to match https://swagger.io/specification/

Required fields are enforced with `@enforce_keys`
Optional fields are typed as `something | nil`

@ThomasRueckert would you mind taking a look over these changes and let me know if it breaks your code?