### PR TITLE
fixing param validation when request body object and query param is defined

### DIFF
--- a/examples/phoenix_app/lib/phoenix_app_web/controllers/user_controller.ex
+++ b/examples/phoenix_app/lib/phoenix_app_web/controllers/user_controller.ex
@@ -34,6 +34,9 @@ defmodule PhoenixAppWeb.UserController do
       summary: "Create user",
       description: "Create a user",
       operationId: "UserController.create",
+      parameters: [
+        Operation.parameter(:group_id, :path, :integer, "Group ID", example: 1)
+      ],
       requestBody: request_body("The user attributes", "application/json", Schemas.UserRequest, required: true),
       responses: %{
         201 => response("User", "application/json", Schemas.UserResponse)

--- a/examples/phoenix_app/test/phoenix_app_web/controllers/user_controller_test.exs
+++ b/examples/phoenix_app/test/phoenix_app_web/controllers/user_controller_test.exs
@@ -9,7 +9,7 @@ defmodule PhoenixAppWeb.UserControllerTest do
   test "create user", %{conn: conn, spec: spec} do
     conn
     |> Plug.Conn.put_req_header("content-type", "application/json")
-    |> post(user_path(conn, :create, %{"user" => %{"name" => "Joe", "email" => "joe@gmail.com"}}))
+    |> post(user_path(conn, :create), %{"user" => %{"name" => "Joe", "email" => "joe@gmail.com"}, "group_id" => 1})
     |> json_response(201)
     |> assert_schema("UserResponse", spec)
   end

--- a/lib/open_api_spex/operation.ex
+++ b/lib/open_api_spex/operation.ex
@@ -199,9 +199,10 @@ defmodule OpenApiSpex.Operation do
   end
 
   @spec validate_parameter_schemas([Parameter.t], map, %{String.t => Schema.t}) :: {:ok, map} | {:error, String.t}
-  defp validate_parameter_schemas([], params, _schemas), do: {:ok, params}
-  defp validate_parameter_schemas([p | rest], params, schemas) do
-    with :ok <- Schema.validate(Parameter.schema(p), params[p.name], schemas),
+  defp validate_parameter_schemas([], %{} = params, _schemas), do: {:ok, params}
+  defp validate_parameter_schemas([p | rest], %{} = params, schemas) do
+    {:ok, parameter_value} = Map.fetch(params, p.name)
+    with :ok <- Schema.validate(Parameter.schema(p), parameter_value, schemas),
          {:ok, remaining} <- validate_parameter_schemas(rest, params, schemas) do
       {:ok, Map.delete(remaining, p.name)}
     end


### PR DESCRIPTION
* updated function validate_parameter_schemas/3
* updated phoenix example user controller: create action now has a query param
* updated test for create user, now also giving a query param to reproduce bug #24 