### PR TITLE
polymorphic cast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 2.2.0
+
+- Feature: Support composite schemas in `OpenApiSpex.schema`
+
+structs defined with `OpenApiSpex.schema` will include all properties defined in schemas
+listed in `allOf`. See the `OpenApiSpex.Schema` docs for some examples.
+
+- Feature: Support composite and polymorphic schemas with `OpenApiSpex.cast/3`.
+   -  `discriminator` is used to cast polymorphic shemas to a more specific schema.
+   -  `allOf` will cast all properties in each included schema
+   -  `oneOf` / `anyOf` will attempt to use each schema until a successful cast is made
+
 # 2.1.1
 
 - Fix: (#24, #25) Operations that define `parameters` and a `requestBody` schema can be validated.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Leverage Open Api Specification 3 (swagger) to document, test, validate and expl
  - Validate responses against schemas in tests, ensuring your docs are accurate and reliable
  - Explore the API interactively with with [SwaggerUI](https://swagger.io/swagger-ui/)
 
+Full documentation available on [hexdocs](https://hexdocs.pm/open_api_spex/)
+
 ## Installation
 
 The package can be installed by adding `open_api_spex` to your list of dependencies in `mix.exs`:
@@ -25,7 +27,7 @@ end
 
 ## Generate Spec
 
-Start by adding an `ApiSpec` module to your application.
+Start by adding an `ApiSpec` module to your application to populate an `OpenApiSpex.OpenApi` struct.
 
 ```elixir
 defmodule MyApp.ApiSpec do
@@ -50,7 +52,7 @@ end
 ```
 
 For each plug (controller) that will handle api requests, add an `open_api_operation` callback.
-It will be passed the plug opts that were declared in the router, this will be the action for a phoenix controller.
+It will be passed the plug opts that were declared in the router, this will be the action for a phoenix controller. The callback populates an `OpenApiSpex.Operation` struct describing the plug/action.
 
 ```elixir
 defmodule MyApp.UserController do
@@ -84,8 +86,10 @@ end
 ```
 
 Declare the JSON schemas for request/response bodies in a `Schemas` module:
-Each module should export a `schema/0` function, and may optionally declare a struct,
-linked to the JSON schema through the `x-struct` extension property.
+Each module should implement the `OpenApiSpex.Schema` behaviour.
+The only callback is `schema/0`, which should return an `OpenApiSpex.Schema` struct.
+You may optionally declare a struct, linked to the JSON schema through the `x-struct` extension property.
+See `OpenApiSpex.schema/1` macro for a convenient way to reduce some boilerplate.
 
 ```elixir
 defmodule MyApp.Schemas do
@@ -234,6 +238,7 @@ defmodule MyApp.UserController do
   end
 end
 ```
+See also `OpenApiSpex.cast/3` and `OpenApiSpex.Schema.cast/3` for more examples outside of a `plug` pipeline.
 
 
 ## Validate Params
@@ -252,6 +257,8 @@ The response body will include the validation error message:
 ```
 #/user/name: Value does not match pattern: [a-zA-Z][a-zA-Z0-9_]+
 ```
+
+See `OpenApiSpex.validate/3` and `OpenApiSpex.Schema.validate/3` for usage outside of a plug pipeline.
 
 ## Validate Examples
 

--- a/lib/open_api_spex.ex
+++ b/lib/open_api_spex.ex
@@ -92,7 +92,7 @@ defmodule OpenApiSpex do
       @schema struct(OpenApiSpex.Schema, Map.put(unquote(body), :"x-struct",  __MODULE__))
       def schema, do: @schema
       @derive [Poison.Encoder]
-      defstruct (@schema.properties || %{}) |> Map.keys()
+      defstruct Schema.properties(@schema)
       @type t :: %__MODULE__{}
     end
   end

--- a/lib/open_api_spex.ex
+++ b/lib/open_api_spex.ex
@@ -19,45 +19,69 @@ defmodule OpenApiSpex do
 
   See `OpenApiSpex.schema` macro for a convenient syntax for defining schema modules.
   """
+  @spec resolve_schema_modules(OpenApi.t) :: OpenApi.t
   def resolve_schema_modules(spec = %OpenApi{}) do
     SchemaResolver.resolve_schema_modules(spec)
   end
 
   @doc """
-  Cast params to conform to a Schema or Operation spec.
+  Cast params to conform to a `OpenApiSpex.Schema`.
+
+  See `OpenApiSpex.Schema.cast/3` for additional examples and details.
   """
-  @spec cast(OpenApi.t, Schema.t | Reference.t | Operation.t, any) :: {:ok, any} | {:error, String.t}
+  @spec cast(OpenApi.t, Schema.t | Reference.t, any) :: {:ok, any} | {:error, String.t}
   def cast(spec = %OpenApi{}, schema = %Schema{}, params) do
     Schema.cast(schema, params, spec.components.schemas)
   end
   def cast(spec = %OpenApi{}, schema = %Reference{}, params) do
     Schema.cast(schema, params, spec.components.schemas)
   end
+
+  @doc """
+  Cast all params in `Plug.Conn` to conform to the schemas for `OpenApiSpex.Operation`.
+
+  `content_type` may optionally be supplied to select the `requestBody` schema.
+  """
+  @spec cast(OpenApi.t, Operation.t, Plug.Conn.t, content_type | nil) :: {:ok, any} | {:error, String.t}
+      when content_type: String.t
   def cast(spec = %OpenApi{}, operation = %Operation{}, conn = %Plug.Conn{}, content_type \\ nil) do
     Operation.cast(operation, conn, content_type, spec.components.schemas)
   end
 
   @doc """
-  Validate params against a Schema or Operation spec.
+  Validate params against `OpenApiSpex.Schema`.
+
+  See `OpenApiSpex.Schema.validate/3` for examples of error messages.
   """
+  @spec validate(OpenApi.t, Schema.t | Reference.t, any) :: :ok | {:error, String.t}
   def validate(spec = %OpenApi{}, schema = %Schema{}, params) do
     Schema.validate(schema, params, spec.components.schemas)
   end
   def validate(spec = %OpenApi{}, schema = %Reference{}, params) do
     Schema.validate(schema, params, spec.components.schemas)
   end
+
+  @doc """
+  Validate all params in `Plug.Conn` against `OpenApiSpex.Operation` `parameter` and `requestBody` schemas.
+
+  `content_type` may be optionally supplied to select the `requestBody` schema.
+  """
+  @spec validate(OpenApi.t, Operation.t, Plug.Conn.t, content_type | nil) :: :ok | {:error, String.t}
+      when content_type: String.t
   def validate(spec = %OpenApi{}, operation = %Operation{}, conn = %Plug.Conn{}, content_type \\ nil) do
     Operation.validate(operation, conn, content_type, spec.components.schemas)
   end
 
   @doc """
-  Declares a OpenApiSpex Schema
+  Declares a struct based `OpenApiSpex.Schema`
 
    - defines the schema/0 callback
    - ensures the schema is linked to the module by "x-struct" extension property
    - defines a struct with keys matching the schema properties
    - defines a @type `t` for the struct
    - derives a `Poison.Encoder` for the struct
+
+  See `OpenApiSpex.Schema` for additional examples and details.
 
   ## Example
 

--- a/lib/open_api_spex/discriminator.ex
+++ b/lib/open_api_spex/discriminator.ex
@@ -3,6 +3,8 @@ defmodule OpenApiSpex.Discriminator do
   Defines the `OpenApiSpex.Discriminator.t` type.
   """
 
+  alias OpenApiSpex.Schema
+
   @enforce_keys :propertyName
   defstruct [
     :propertyName,
@@ -21,4 +23,42 @@ defmodule OpenApiSpex.Discriminator do
     propertyName: String.t,
     mapping: %{String.t => String.t} | nil
   }
+
+  @doc """
+  Resolve the schema that should be used to cast/validate a value using a `Discriminator`.
+  """
+  @spec resolve(t, map, %{String.t => Schema.t}) :: {:ok, Schema.t} | {:error, String.t}
+  def resolve(%{propertyName: name, mapping: mapping}, value = %{}, schemas = %{}) do
+    with {:ok, val} <- get_property_value(value, name) do
+      mapped = map_property_value(mapping, val)
+      lookup_schema(schemas, mapped)
+    else
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @spec get_property_value(map, String.t) :: {:ok, any} | {:error, String.t}
+  defp get_property_value(value = %{}, property_name) do
+    case Map.fetch(value, property_name) do
+      {:ok, val} -> {:ok, val}
+      :error -> {:error, "No value for required disciminator property: #{property_name}"}
+    end
+  end
+
+  @spec map_property_value(%{String.t => String.t} | nil, String.t) :: String.t
+  defp map_property_value(nil, val), do: val
+  defp map_property_value(mapping = %{}, val) do
+    Map.get(mapping, val, val)
+  end
+
+  @spec lookup_schema(%{String.t => Schema.t}, String.t) :: {:ok, Schema.t} | {:error, String.t}
+  defp lookup_schema(schemas, "#components/schemas/" <> name) do
+    lookup_schema(schemas, name)
+  end
+  defp lookup_schema(schemas, name) do
+    case Map.fetch(schemas, name) do
+      {:ok, schema} -> {:ok, schema}
+      :error -> {:error, "Unknown schema: #{name}"}
+    end
+  end
 end

--- a/lib/open_api_spex/test/assertions.ex
+++ b/lib/open_api_spex/test/assertions.ex
@@ -18,8 +18,19 @@ defmodule OpenApiSpex.Test.Assertions do
       flunk("Schema: #{schema_title} not found in #{inspect(Map.keys(schemas))}")
     end
 
-    _ = assert {:ok, data} = OpenApiSpex.cast(api_spec, schema, value)
-    _ = assert :ok = OpenApiSpex.validate(api_spec, schema, data)
+
+    data =
+      case OpenApiSpex.cast(api_spec, schema, value) do
+        {:ok, data} -> data
+        {:error, reason} ->
+          flunk("Value does not conform to schema #{schema_title}: #{reason}\n#{inspect value}")
+      end
+
+    case OpenApiSpex.validate(api_spec, schema, data) do
+      :ok -> :ok
+      {:error, reason} ->
+        flunk("Value does not conform to schema #{schema_title}: #{reason}\n#{inspect value}")
+    end
 
     data
   end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule OpenApiSpex.Mixfile do
   use Mix.Project
 
-  @version "2.1.1"
+  @version "2.2.0"
 
   def project do
     [

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -102,8 +102,7 @@ defmodule OpenApiSpex.SchemaTest do
     assert {:ok, 123.0} = result
   end
 
-  @tag :focus
-  test "Cast string to number or datetime" do
+  test "Cast string to oneOf number or datetime" do
     schema = %Schema{
       oneOf: [
         %Schema{type: :number},
@@ -113,4 +112,13 @@ defmodule OpenApiSpex.SchemaTest do
     assert {:ok, %DateTime{}} = Schema.cast(schema, "2018-04-01T12:34:56Z", %{})
   end
 
+  test "Cast string to anyOf number or datetime" do
+    schema = %Schema{
+      oneOf: [
+        %Schema{type: :number},
+        %Schema{type: :string, format: :"date-time"}
+      ]
+    }
+    assert {:ok, %DateTime{}} = Schema.cast(schema, "2018-04-01T12:34:56Z", %{})
+  end
 end

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -75,4 +75,42 @@ defmodule OpenApiSpex.SchemaTest do
 
     assert {:ok, %Schemas.Cat{meow: "meow", pet_type: "Cat"}} = Schema.cast(pet_schema, input, schemas)
   end
+
+  test "Cast Dog from oneOf [cat, dog] schema" do
+    api_spec = ApiSpec.spec()
+    schemas = api_spec.components.schemas
+    cat_or_dog = Map.fetch!(schemas, "CatOrDog")
+
+    input = %{
+      "pet_type" => "Cat",
+      "meow" => "meow"
+    }
+
+    assert {:ok, %Schemas.Cat{meow: "meow", pet_type: "Cat"}} = Schema.cast(cat_or_dog, input, schemas)
+  end
+
+  test "Cast number to string or number" do
+    schema = %Schema{
+      oneOf: [
+        %Schema{type: :number},
+        %Schema{type: :string}
+      ]
+    }
+
+    result = Schema.cast(schema, "123", %{})
+
+    assert {:ok, 123.0} = result
+  end
+
+  @tag :focus
+  test "Cast string to number or datetime" do
+    schema = %Schema{
+      oneOf: [
+        %Schema{type: :number},
+        %Schema{type: :string, format: :"date-time"}
+      ]
+    }
+    assert {:ok, %DateTime{}} = Schema.cast(schema, "2018-04-01T12:34:56Z", %{})
+  end
+
 end

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -62,4 +62,17 @@ defmodule OpenApiSpex.SchemaTest do
     assert_schema(Schemas.UserResponse.schema().example, "UserResponse", spec)
     assert_schema(Schemas.UsersResponse.schema().example, "UsersResponse", spec)
   end
+
+  test "Cast Cat from Pet schema" do
+    api_spec = ApiSpec.spec()
+    schemas = api_spec.components.schemas
+    pet_schema = schemas["Pet"]
+
+    input = %{
+      "pet_type" => "Cat",
+      "meow" => "meow"
+    }
+
+    assert {:ok, %Schemas.Cat{meow: "meow", pet_type: "Cat"}} = Schema.cast(pet_schema, input, schemas)
+  end
 end

--- a/test/support/api_spec.ex
+++ b/test/support/api_spec.ex
@@ -1,5 +1,5 @@
 defmodule OpenApiSpexTest.ApiSpec do
-  alias OpenApiSpex.{OpenApi, Contact, License, Paths, Schema, Server, Info, Components}
+  alias OpenApiSpex.{OpenApi, Contact, License, Paths, Server, Info, Components}
   alias OpenApiSpexTest.{Router, Schemas}
 
   def spec() do

--- a/test/support/api_spec.ex
+++ b/test/support/api_spec.ex
@@ -1,5 +1,5 @@
 defmodule OpenApiSpexTest.ApiSpec do
-  alias OpenApiSpex.{OpenApi, Contact, License, Paths, Server, Info, Components}
+  alias OpenApiSpex.{OpenApi, Contact, License, Paths, Schema, Server, Info, Components}
   alias OpenApiSpexTest.{Router, Schemas}
 
   def spec() do
@@ -21,11 +21,11 @@ defmodule OpenApiSpexTest.ApiSpec do
         }
       },
       components: %Components{
-        schemas: %{
-          "Pet" => Schemas.Pet.schema(),
-          "Cat" => Schemas.Cat.schema(),
-          "Dog" => Schemas.Dog.schema()
-        }
+        schemas:
+          for schemaMod <- [Schemas.Pet, Schemas.Cat, Schemas.Dog, Schemas.CatOrDog], into: %{} do
+            schema = schemaMod.schema()
+            {schema.title, schema}
+          end
       },
       paths: Paths.from_router(Router)
     }

--- a/test/support/api_spec.ex
+++ b/test/support/api_spec.ex
@@ -1,6 +1,6 @@
 defmodule OpenApiSpexTest.ApiSpec do
-  alias OpenApiSpex.{OpenApi, Contact, License, Paths, Server, Info}
-  alias OpenApiSpexTest.Router
+  alias OpenApiSpex.{OpenApi, Contact, License, Paths, Server, Info, Components}
+  alias OpenApiSpexTest.{Router, Schemas}
 
   def spec() do
     %OpenApi{
@@ -18,6 +18,13 @@ defmodule OpenApiSpexTest.ApiSpec do
         license: %License{
           name: "MIT",
           url: "http://mit.edu/license"
+        }
+      },
+      components: %Components{
+        schemas: %{
+          "Pet" => Schemas.Pet.schema(),
+          "Cat" => Schemas.Cat.schema(),
+          "Dog" => Schemas.Dog.schema()
         }
       },
       paths: Paths.from_router(Router)

--- a/test/support/schemas.ex
+++ b/test/support/schemas.ex
@@ -216,4 +216,13 @@ defmodule OpenApiSpexTest.Schemas do
       ]
     })
   end
+
+  defmodule CatOrDog do
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "CatOrDog",
+      oneOf: [Cat, Dog]
+    })
+  end
 end

--- a/test/support/schemas.ex
+++ b/test/support/schemas.ex
@@ -156,4 +156,64 @@ defmodule OpenApiSpexTest.Schemas do
       }
     }
   end
+
+  defmodule Pet do
+    require OpenApiSpex
+
+    alias OpenApiSpex.{Schema, Discriminator}
+
+    OpenApiSpex.schema(%{
+      title: "Pet",
+      type: :object,
+      properties: %{
+        pet_type: %Schema{type: :string}
+      },
+      required: [:pet_type],
+      discriminator: %Discriminator{
+        propertyName: "pet_type"
+      }
+    })
+  end
+
+  defmodule Cat do
+    require OpenApiSpex
+
+    alias OpenApiSpex.Schema
+
+    OpenApiSpex.schema(%{
+      title: "Cat",
+      type: :object,
+      allOf: [
+        Pet,
+        %Schema{
+          type: :object,
+          properties: %{
+            meow: %Schema{type: :string}
+          },
+          required: [:meow]
+        }
+      ]
+    })
+  end
+
+  defmodule Dog do
+    require OpenApiSpex
+
+    alias OpenApiSpex.Schema
+
+    OpenApiSpex.schema(%{
+      title: "Dog",
+      type: :object,
+      allOf: [
+        Pet,
+        %Schema{
+          type: :object,
+          properties: %{
+            bark: %Schema{type: :string}
+          },
+          required: [:bark]
+        }
+      ]
+    })
+  end
 end


### PR DESCRIPTION
Proof of concept support for casting polymorphic schemas using `discriminator` / `allOf`

@maxmellen I'd appreciate if you could take a look over this branch and see if you'd like to expand support for `oneOf` / `allOf`.

I'm not 100% happy with the `tag` / `untag` functions, but I couldn't come up with a cleaner way to prevent infinite recursion.

The biggest limitation now is that the struct types declared with the `OpenApiSpex.schema` macro don't contain any fields. The macro only looks at the `properties` key.  It should be possible to merge all the properties for schemas appearing in `allOf`.