### PR TITLE
Handle enum for string values

### DIFF
--- a/lib/open_api_spex/schema.ex
+++ b/lib/open_api_spex/schema.ex
@@ -442,7 +442,8 @@ defmodule OpenApiSpex.Schema do
   def validate(schema = %Schema{type: :string}, value, path, _schemas) do
     with :ok <- validate_max_length(schema, value, path),
          :ok <- validate_min_length(schema, value, path),
-         :ok <- validate_pattern(schema, value, path) do
+         :ok <- validate_pattern(schema, value, path),
+         :ok <- validate_enum(schema, value, path) do
       :ok
     end
   end
@@ -516,6 +517,16 @@ defmodule OpenApiSpex.Schema do
     case Regex.match?(regex, val) do
       true -> :ok
       _ -> {:error, "#{path}: Value does not match pattern: #{regex.source}"}
+    end
+  end
+
+  @spec validate_enum(Schema.t, String.t, String.t) :: :ok | {:error, String.t}
+  def validate_enum(%{enum: nil}, _val, _path), do: :ok
+  def validate_enum(%{enum: options}, value, path) do
+    case Enum.member?(options, value) do
+      true -> :ok
+      _ ->
+        {:error, "#{path}: Value not in enum: #{Enum.join(options, ", ")}"}
     end
   end
 

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -121,4 +121,21 @@ defmodule OpenApiSpex.SchemaTest do
     }
     assert {:ok, %DateTime{}} = Schema.cast(schema, "2018-04-01T12:34:56Z", %{})
   end
+
+  test "Validate string with unexpected value" do
+    schema = %Schema{
+      type: :string,
+      enum: ["foo", "bar"]
+    }
+    assert {:error, _} = Schema.validate(schema, "baz", %{})
+  end
+
+  test "Validate string with expected value" do
+    schema = %Schema{
+      type: :string,
+      enum: ["foo", "bar"]
+    }
+    assert :ok = Schema.validate(schema, "bar", %{})
+  end
+
 end


### PR DESCRIPTION
Hi there,

thanks for the nice framework.

While using the enum with strings I realised that the verification is not implemented yet. This change adds verification for strings when the enum options is given. Casting will fail if the value is not one of the given options.
