### PR TITLE
Fix parameter style

### DIFF
--- a/lib/open_api_spex/parameter.ex
+++ b/lib/open_api_spex/parameter.ex
@@ -30,7 +30,7 @@ defmodule OpenApiSpex.Parameter do
   @typedoc """
   Valid values for the `style` key in the `OpenApiSpex.Parameter` struct.
   """
-  @type style :: :matrix | :label | :form | :simple | :spaceDelimited | :pipeDelimited | :deep
+  @type style :: :matrix | :label | :form | :simple | :spaceDelimited | :pipeDelimited | :deepObject
 
   @typedoc """
   [Parameter Object](https://swagger.io/specification/#parameterObject)


### PR DESCRIPTION
Change `:deep` to `:deepObject`
according to https://swagger.io/docs/specification/describing-parameters/#query-parameters