### PR TITLE
Cast and validate body_params separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ All javascript and CSS assets are sourced from cdnjs.cloudflare.com, rather than
 
 ## Cast Params
 
-Add the `OpenApiSpex.Plug.Cast` plug to a controller to cast the request parameters to elixir types defined by the operation schema.
+Add the `OpenApiSpex.Plug.Cast` plug to a controller to cast the request parameters and body to elixir types defined by the operation schema.
 
 ```elixir
 plug OpenApiSpex.Plug.Cast, operation_id: "UserController.show"
@@ -225,7 +225,9 @@ defmodule MyApp.UserController do
       summary: "Create user",
       description: "Create a user",
       operationId: "UserController.create",
-      parameters: [],
+      parameters: [
+        parameter(:id, :query, :integer, "user ID")
+      ],
       requestBody: request_body("The user attributes", "application/json", UserRequest),
       responses: %{
         201 => response("User", "application/json", UserResponse)
@@ -233,8 +235,9 @@ defmodule MyApp.UserController do
     }
   end
 
-  def create(conn, %UserRequest{user: %User{name: name, email: email, birthday: birthday = %Date{}}}) do
-    # params are cast to UserRequest struct
+  def create(conn = %{body_params: %UserRequest{user: %User{name: name, email: email, birthday: birthday = %Date{}}}}, %{id: id}) do
+    # conn.body_params cast to UserRequest struct
+    # conn.params.id cast to integer
   end
 end
 ```

--- a/lib/open_api_spex.ex
+++ b/lib/open_api_spex.ex
@@ -40,9 +40,12 @@ defmodule OpenApiSpex do
   @doc """
   Cast all params in `Plug.Conn` to conform to the schemas for `OpenApiSpex.Operation`.
 
+  Returns `{:ok, Plug.Conn.t}` with `params` and `body_params` fields updated if successful,
+  or `{:error, reason}` if casting fails.
+
   `content_type` may optionally be supplied to select the `requestBody` schema.
   """
-  @spec cast(OpenApi.t, Operation.t, Plug.Conn.t, content_type | nil) :: {:ok, any} | {:error, String.t}
+  @spec cast(OpenApi.t, Operation.t, Plug.Conn.t, content_type | nil) :: {:ok, Plug.Conn.t} | {:error, String.t}
       when content_type: String.t
   def cast(spec = %OpenApi{}, operation = %Operation{}, conn = %Plug.Conn{}, content_type \\ nil) do
     Operation.cast(operation, conn, content_type, spec.components.schemas)

--- a/lib/open_api_spex/plug/cast.ex
+++ b/lib/open_api_spex/plug/cast.ex
@@ -1,6 +1,8 @@
 defmodule OpenApiSpex.Plug.Cast do
   @moduledoc """
-  Module plug that will cast the `Conn.params` according to the schemas defined for the operation.
+  Module plug that will cast the `Conn.params` and `Conn.body_params` according to the schemas defined for the operation.
+  Note that when using this plug, the body params are no longer merged into `Conn.params` and must be read from `Conn.body_params`
+  separately.
 
   The operation_id can be given at compile time as an argument to `init`:
 
@@ -31,7 +33,7 @@ defmodule OpenApiSpex.Plug.Cast do
     conn = Conn.put_private(conn, :open_api_spex, private_data)
 
     case OpenApiSpex.cast(spec, operation, conn, content_type) do
-      {:ok, params} -> %{conn | params: params}
+      {:ok, conn} -> conn
       {:error, reason} ->
         conn
         |> Plug.Conn.send_resp(422, "#{reason}")

--- a/test/open_api_spex_test.exs
+++ b/test/open_api_spex_test.exs
@@ -24,7 +24,7 @@ defmodule OpenApiSpexTest do
         |> Plug.Conn.put_req_header("content-type", "application/json")
         |> OpenApiSpexTest.Router.call([])
 
-      assert conn.params == %OpenApiSpexTest.Schemas.UserRequest{
+      assert conn.body_params == %OpenApiSpexTest.Schemas.UserRequest{
         user: %OpenApiSpexTest.Schemas.User{
           id: 123,
           name: "asdf",

--- a/test/param_test.exs
+++ b/test/param_test.exs
@@ -32,5 +32,20 @@ defmodule ParamTest do
       assert conn.status == 422
       assert conn.resp_body == "Undefined query parameter: \"inValid2\""
     end
+
+    test "with requestBody" do
+      body = Poison.encode!(%{
+        phone_number: "123-456-789",
+        postal_address: "123 Lane St"
+      })
+
+      conn =
+        :post
+        |> Plug.Test.conn("/api/users/123/contact_info", body)
+        |> Plug.Conn.put_req_header("content-type", "application/json")
+        |> OpenApiSpexTest.Router.call([])
+
+      assert conn.status == 200
+    end
   end
 end

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -14,6 +14,7 @@ defmodule OpenApiSpexTest.Router do
     pipe_through :api
     resources "/users", UserController, only: [:create, :index, :show]
     get "/users/:id/payment_details", UserController, :payment_details
+    post "/users/:id/contact_info", UserController, :contact_info
     post "/users/create_entity", UserController, :create_entity
     get "/openapi", RenderSpec, []
   end

--- a/test/support/schemas.ex
+++ b/test/support/schemas.ex
@@ -26,6 +26,24 @@ defmodule OpenApiSpexTest.Schemas do
     }
   end
 
+  defmodule ContactInfo do
+    OpenApiSpex.schema %{
+      title: "ContactInfo",
+      description: "A users contact information",
+      type: :object,
+      properties: %{
+        phone_number: %Schema{type: :string, description: "Phone number"},
+        postal_address: %Schema{type: :string, description: "Postal address"}
+      },
+      required: [:phone_number],
+      additionalProperties: false,
+      example: %{
+        "phone_number" => "555-123-456",
+        "postal_address" => "123 Evergreen Tce"
+      }
+    }
+  end
+
   defmodule CreditCardPaymentDetails do
     OpenApiSpex.schema %{
       title: "CreditCardPaymentDetails",
@@ -109,8 +127,7 @@ defmodule OpenApiSpexTest.Schemas do
           "inserted_at" => "2017-09-12T12:34:55Z",
           "updated_at" => "2017-09-13T10:11:12Z"
         }
-      },
-      "x-struct": __MODULE__
+      }
     }
   end
 

--- a/test/support/user_controller.ex
+++ b/test/support/user_controller.ex
@@ -79,10 +79,34 @@ defmodule OpenApiSpexTest.UserController do
       }
     }
   end
-  def create(conn, %Schemas.UserRequest{user: user = %Schemas.User{}}) do
+  def create(conn = %{body_params: %Schemas.UserRequest{user: user = %Schemas.User{}}}, _) do
     json(conn, %Schemas.UserResponse{
       data: %{user | id: 1234}
     })
+  end
+
+  def contact_info_operation() do
+    import Operation
+    %Operation{
+      tags: ["users"],
+      summary: "Update contact info",
+      description: "Update contact info",
+      operationId: "UserController.contact_info",
+      parameters: [
+        parameter(:id, :path, :integer, "user ID")
+      ],
+      requestBody: request_body("Contact info", "application/json", Schemas.ContactInfo),
+      responses: %{
+        200 => %OpenApiSpex.Response{
+          description: "OK"
+        }
+      }
+    }
+  end
+  def contact_info(conn = %{body_params: %Schemas.ContactInfo{}}, %{id: id}) do
+    conn
+    |> put_status(200)
+    |> json(%{id: id})
   end
 
   def payment_details_operation() do


### PR DESCRIPTION
This change is motivated by the unintuitive behaviour of
merging the cast request body with the query/path params
into a single struct.

Matching on such a struct produces a compile error.

Since `Plug.Conn` already has a field to store `body_params`,
we use that to hold the cast requestBody.

matching on the requestBody in a controller now requires:

```elixir
def create(conn = %{body_params: %SomeType{}}, other_params = %{}) do
...
end
```