### PR TITLE
ignore charset in content-type header when mapping schema

### DIFF
--- a/lib/open_api_spex/plug/cast.ex
+++ b/lib/open_api_spex/plug/cast.ex
@@ -26,7 +26,10 @@ defmodule OpenApiSpex.Plug.Cast do
   def call(conn = %{private: %{open_api_spex: private_data}}, operation_id: operation_id) do
     spec = private_data.spec
     operation = private_data.operation_lookup[operation_id]
-    content_type = Conn.get_req_header(conn, "content-type") |> Enum.at(0)
+    content_type = Conn.get_req_header(conn, "content-type") 
+        |> Enum.at(0)
+        |> String.split(";")
+        |> Enum.at(0)
     private_data = Map.put(private_data, :operation_id, operation_id)
     conn = Conn.put_private(conn, :open_api_spex, private_data)
 

--- a/lib/open_api_spex/plug/validate.ex
+++ b/lib/open_api_spex/plug/validate.ex
@@ -28,7 +28,10 @@ defmodule OpenApiSpex.Plug.Validate do
     operation_id = conn.private.open_api_spex.operation_id
     operation_lookup = conn.private.open_api_spex.operation_lookup
     operation = operation_lookup[operation_id]
-    content_type = Conn.get_req_header(conn, "content-type") |> Enum.at(0)
+    content_type = Conn.get_req_header(conn, "content-type")
+        |> Enum.at(0)
+        |> String.split(";")
+        |> Enum.at(0)
 
     with :ok <- OpenApiSpex.validate(spec, operation, conn, content_type) do
       conn

--- a/test/open_api_spex_test.exs
+++ b/test/open_api_spex_test.exs
@@ -21,7 +21,7 @@ defmodule OpenApiSpexTest do
       conn =
         :post
         |> Plug.Test.conn("/api/users", Poison.encode!(request_body))
-        |> Plug.Conn.put_req_header("content-type", "application/json")
+        |> Plug.Conn.put_req_header("content-type", "application/json; charset=UTF-8")
         |> OpenApiSpexTest.Router.call([])
 
       assert conn.params == %OpenApiSpexTest.Schemas.UserRequest{


### PR DESCRIPTION
We've seen the following error on requests with content-type `application/json; charset=UTF-8`. I added that to one of the tests to deal with the two instances where content-type is used.

Elixir.UndefinedFunctionError: function nil.schema/0 is undefined or private
  ?, in nil.schema/0
  File "lib/open_api_spex/operation.ex", line 170, in OpenApiSpex.Operation.cast_request_body/4
  File "lib/open_api_spex/operation.ex", line 129, in OpenApiSpex.Operation.cast/4
  File "lib/open_api_spex/plug/cast.ex", line 33, in OpenApiSpex.Plug.Cast.call/2