### PR TITLE
Make error response configurable

### DIFF
--- a/lib/open_api_spex/plug/default_render_error.ex
+++ b/lib/open_api_spex/plug/default_render_error.ex
@@ -1,0 +1,14 @@
+defmodule OpenApiSpex.Plug.DefaultRenderError do
+
+  @behaviour Plug
+
+  alias Plug.Conn
+
+  @impl Plug
+  def init(opts), do: opts
+
+  @impl Plug
+  def call(conn, reason) do
+    conn |> Conn.send_resp(422, "#{reason}")
+  end
+end

--- a/test/param_test.exs
+++ b/test/param_test.exs
@@ -33,4 +33,38 @@ defmodule ParamTest do
       assert conn.resp_body == "Undefined query parameter: \"inValid2\""
     end
   end
+
+  describe "Param with custom error handling" do
+    test "Valid Param" do
+      conn =
+        :get
+        |> Plug.Test.conn("/api/custom_error_users?validParam=true")
+        |> Plug.Conn.put_req_header("content-type", "application/json")
+        |> OpenApiSpexTest.Router.call([])
+
+      assert conn.status == 200
+    end
+
+    test "Invalid value" do
+      conn =
+        :get
+        |> Plug.Test.conn("/api/custom_error_users?validParam=123")
+        |> Plug.Conn.put_req_header("content-type", "application/json")
+        |> OpenApiSpexTest.Router.call([])
+
+      assert conn.status == 400
+    end
+
+    test "Invalid Param" do
+      conn =
+        :get
+        |> Plug.Test.conn("/api/custom_error_users?validParam=123&inValidParam=123&inValid2=hi")
+        |> Plug.Conn.put_req_header("content-type", "application/json")
+        |> OpenApiSpexTest.Router.call([])
+
+      assert conn.status == 400
+      assert conn.resp_body == "Undefined query parameter: \"inValid2\""
+    end
+  end
+
 end

--- a/test/support/custom_error_user_controller.ex
+++ b/test/support/custom_error_user_controller.ex
@@ -1,0 +1,56 @@
+defmodule OpenApiSpexTest.CustomErrorUserController do
+  use Phoenix.Controller
+  alias OpenApiSpex.Operation
+  alias OpenApiSpexTest.Schemas
+  alias Plug.Conn
+
+  defmodule CustomRenderErrorPlug do
+
+    @behaviour Plug
+
+    alias Plug.Conn
+
+    @impl Plug
+    def init(opts), do: opts
+
+    @impl Plug
+    def call(conn, reason) do
+      conn |> Conn.send_resp(400, "#{reason}")
+    end
+  end
+
+  plug OpenApiSpex.Plug.Cast, render_error: CustomRenderErrorPlug
+  plug OpenApiSpex.Plug.Validate, render_error: CustomRenderErrorPlug
+
+  def open_api_operation(action) do
+    apply(__MODULE__, :"#{action}_operation", [])
+  end
+
+  def index_operation() do
+    import Operation
+    %Operation{
+      tags: ["users"],
+      summary: "List users",
+      description: "List all useres",
+      operationId: "UserController.index",
+      parameters: [
+        parameter(:validParam, :query, :boolean, "Valid Param", example: true)
+      ],
+      responses: %{
+        200 => response("User List Response", "application/json", Schemas.UsersResponse)
+      }
+    }
+  end
+  def index(conn, _params) do
+    json(conn, %Schemas.UsersResponse{
+      data: [
+        %Schemas.User{
+          id: 123,
+          name: "joe user",
+          email: "joe@gmail.com"
+        }
+      ]
+    })
+  end
+
+end

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -2,6 +2,7 @@ defmodule OpenApiSpexTest.Router do
   use Phoenix.Router
   alias Plug.Parsers
   alias OpenApiSpexTest.UserController
+  alias OpenApiSpexTest.CustomErrorUserController
   alias OpenApiSpex.Plug.{PutApiSpec, RenderSpec}
 
   pipeline :api do
@@ -13,6 +14,7 @@ defmodule OpenApiSpexTest.Router do
   scope "/api" do
     pipe_through :api
     resources "/users", UserController, only: [:create, :index, :show]
+    resources "/custom_error_users", CustomErrorUserController, only: [:index]
     get "/users/:id/payment_details", UserController, :payment_details
     post "/users/create_entity", UserController, :create_entity
     get "/openapi", RenderSpec, []


### PR DESCRIPTION
With this PR you can overwrite the existing error response with a custom response:

```
   defmodule MyAppWeb.UserController do
        use Phoenix.Controller
        plug OpenApiSpex.Plug.Cast,
        render_error: MyApp.RenderError
        plug OpenApiSpex.Plug.Validate,
        render_error: MyApp.RenderError
        ...
      end

      defmodule MyApp.RenderError do
        def init(opts), do: opts

        def call(conn, reason) do
          msg = %{error: reason} |> Posion.encode!()

          conn
          |> Conn.put_resp_content_type("application/json")
          |> Conn.send_resp(400, msg)
        end
      end
```