### PR TITLE
Fix compiler warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,9 @@ otp_release:
     - 21.0
 
 script:
- - mix test
- - mix dialyzer --halt-exit-status
+    - mix compile --warnings-as-errors
+    - mix test
+    - mix dialyzer --halt-exit-status
 
 cache:
   directories:

--- a/lib/open_api_spex/operation.ex
+++ b/lib/open_api_spex/operation.ex
@@ -199,7 +199,7 @@ defmodule OpenApiSpex.Operation do
   end
 
   @spec validate_parameter_schemas([Parameter.t], map, %{String.t => Schema.t}) :: :ok | {:error, String.t}
-  defp validate_parameter_schemas([], %{} = params, _schemas), do: :ok
+  defp validate_parameter_schemas([], %{} = _params, _schemas), do: :ok
   defp validate_parameter_schemas([p | rest], %{} = params, schemas) do
     {:ok, parameter_value} = Map.fetch(params, p.name)
     with :ok <- Schema.validate(Parameter.schema(p), parameter_value, schemas) do


### PR DESCRIPTION
Fixes compiler warning:

```
warning: variable "params" is unused
  lib/open_api_spex/operation.ex:202
```

Also adjusts Travis to fail the build when there is a compiler warning.